### PR TITLE
Federal state BB: Fix parcel name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@agvolution/harmonie",
   "type": "module",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [

--- a/src/states/DE-BB.ts
+++ b/src/states/DE-BB.ts
@@ -15,12 +15,13 @@ export default async function bb(query: HarmonieQuery) {
   let count = 0;
   const plots = parzellen.reduce((acc, p) => {
     // start off with main area of field
+    const parzellenName = p["fa:parzellenname"];
     const hnf = p["fa:teilflaechen"]["fa:hauptnutzungsflaeche"];
     acc.push(
       new Field({
         id: `harmonie_${count}_${hnf["fa:flik"]}`,
         referenceDate: applicationYear,
-        NameOfField: "", // seems to be unavailable in Agrarantrag-BB export files?,
+        NameOfField: parzellenName || "",
         NumberOfField: Math.floor(hnf["fa:teilflaechennummer"]),
         Area: hnf["fa:groesse"] / 10000,
         FieldBlockNumber: hnf["fa:flik"],
@@ -50,7 +51,7 @@ export default async function bb(query: HarmonieQuery) {
         new Field({
           id: `harmonie_${count}_${stf["fa:flik"]}`,
           referenceDate: applicationYear,
-          NameOfField: "", // seems to be unavailable in Agrarantrag-BB export files?,
+          NameOfField: parzellenName || "",
           NumberOfField: Math.floor(stf["fa:teilflaechennummer"]),
           Area: stf["fa:groesse"] / 10000,
           FieldBlockNumber: stf["fa:flik"],


### PR DESCRIPTION
This pull request updates the package version and improves how field names are handled for Brandenburg (`DE-BB`) state data processing. The main change ensures that the `NameOfField` property is populated with the parcel name when available, rather than leaving it empty.

Version update:

* Bumped the package version from `2.2.7` to `2.2.8` in `package.json` to reflect the new changes.

Field name handling improvements in Brandenburg state logic:

* Updated the logic in `src/states/DE-BB.ts` to set the `NameOfField` property to the value of `fa:parzellenname` if available, for both main and secondary areas of a field, instead of leaving it empty. [[1]](diffhunk://#diff-1261d1a5a3593de4fa18effc93a3d9fa46266006d73aec1e9bc48e73b96b8265R18-R24) [[2]](diffhunk://#diff-1261d1a5a3593de4fa18effc93a3d9fa46266006d73aec1e9bc48e73b96b8265L53-R54)